### PR TITLE
Makefile for CODeM-Toolkit project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.autosave
+*.o
+CODeM
+*.user

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Target name
+TARGET:=CODeM
+
+# Specify your c++ compiler here
+CXX=g++
+
+# Specify source folders
+SRCDIR:= . #core misc 
+
+# ===============================
+SOURCES := $(shell find $(SRCDIR) -name '*.cpp')
+OBJS:= $(SOURCES:.cpp=.o)
+
+CXXINC=-I$(shell pwd) -I$(shell pwd)/core
+CXXFLAG=-g -O2 -std=c++11 $(CXXINC)
+
+.PHONY: clean all
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS) 
+	@echo " Linking..."
+	$(CXX) $^ -o $(TARGET)
+
+$(OBJS): %.o : %.cpp
+	$(CXX) $(CXXFLAG) -o $@ -c $<
+
+test:
+	./$(TARGET)
+clean:
+	@echo " Cleaning..."; 
+	rm -f $(OBJS)
+	rm -f $(TARGET)

--- a/core/RandomDistributions.cpp
+++ b/core/RandomDistributions.cpp
@@ -503,7 +503,8 @@ void MergedDistribution::addOnePDF(IDistribution* d, double ratio)
 
     //Interpolate the new pdf over the new samples in its range
     LinearInterpolator pdfInterpolator(newZ, newPDF);
-    newPDF.swap(pdfInterpolator.interpolateV(vector<double>(first, last)));
+    vector<double> tmp = pdfInterpolator.interpolateV(vector<double>(first, last));
+    newPDF.swap(tmp);
 
     // add the new pdf times its weight to the existing pdf
     vector<double>::iterator newIter;

--- a/misc/examples/CODeMProblems.cpp
+++ b/misc/examples/CODeMProblems.cpp
@@ -284,8 +284,8 @@ vector<vector<double> > CODeM5Perturb(const vector<double> &iVec,
     double lb = 2.0/4.0;
     double ub = 1.0;
 
-    vector<double> inLB(size(iVec));
-    vector<double> inUB(size(iVec));
+    vector<double> inLB(iVec.size());
+    vector<double> inUB(iVec.size());
 
     createInputBounds(inLB, inUB, 5);
 


### PR DESCRIPTION
## Makefile for CODeM-Toolkit project.

The makefile directs `make` on how to compile and link the program.
This Makefile is intended to be used on Linux systems or Windows systems via mingw.
This makefile can be used to compile the project when `qmake` is not available on the user's machine.
### How to use
1. Open a terminal and `cd` to the root of the project folder.
2. Type `make` in the terminal. This will compile the project and generate the executable.
3. To run a test, simple type `make test` after step 2.
4. Type `make clean` to remove all compiled objects and the executable.
### Customisation
1. Change the value of `TARGET` to use a user defined name for the executable.
2. Change the value of `CXX` to use a different compiler. By default the compiler is g++.
